### PR TITLE
Update Airbrake Heroku addon name

### DIFF
--- a/bin/heroku.rb
+++ b/bin/heroku.rb
@@ -12,7 +12,7 @@
   newrelic:wayne
   librato:development
   pingdom:starter
-  airbrake:free_heroku
+  airbrake:free-hrku
 ).each do |addon|
   `heroku addons:create #{addon} --app waxpoetic-staging`
 end


### PR DESCRIPTION
Airbrake has changed the name of their free plan on Heroku.
